### PR TITLE
Implement MSSQL repository-service architecture

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,15 +16,11 @@ jobs:
         ports:
           - 1433:1433
         options: >-
-          --health-cmd "bash -c 'echo \"SELECT 1\" | /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P YourStrong!Passw0rd'" \
+          --health-cmd "bash -c 'echo \"SELECT 1\" | /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P YourStrong!Passw0rd'"
           --health-interval 10s --health-timeout 30s --health-retries 10
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
+      - uses: dtolnay/rust-toolchain@stable
       - name: Run tests
         run: |
           cargo test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,17 @@ jobs:
           - 1433:1433
         options: >-
           --health-cmd "bash -c 'echo \"SELECT 1\" | /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P YourStrong!Passw0rd'"
-          --health-interval 10s --health-timeout 30s --health-retries 10
+          --health-interval 10s --health-timeout 30s --health-retries 20 --health-start-period 30s
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - name: Wait for MSSQL
+        run: |
+          for i in {1..30}; do
+            nc -z localhost 1433 && echo "MSSQL is up" && break
+            echo "Waiting for MSSQL..."
+            sleep 10
+          done
       - name: Run tests
         run: |
           cargo test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    services:
+      mssql:
+        image: mcr.microsoft.com/mssql/server:2022-latest
+        env:
+          SA_PASSWORD: "YourStrong!Passw0rd"
+          ACCEPT_EULA: "Y"
+        ports:
+          - 1433:1433
+        options: >-
+          --health-cmd "bash -c 'echo \"SELECT 1\" | /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P YourStrong!Passw0rd'" \
+          --health-interval 10s --health-timeout 30s --health-retries 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+      - name: Run tests
+        run: |
+          cargo test
+          cargo test -- --ignored

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,6 @@ jobs:
           ACCEPT_EULA: "Y"
         ports:
           - 1433:1433
-        options: >-
-          --health-cmd "bash -c 'echo \"SELECT 1\" | /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P YourStrong!Passw0rd'"
-          --health-interval 10s --health-timeout 30s --health-retries 20 --health-start-period 30s
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,9 @@ thiserror = "2.0.16"
 futures = "0.3"
 chrono = { version = "0.4.41", features = ["clock"] }
 base64 = "0.22"
-tiberius = { version = "0.12.3", features = ["tls-native", "tds73", "chrono", "rust_decimal"] }
-tokio-util = "0.7"
+tiberius = { version = "0.12.3", features = ["native-tls", "tds73", "chrono", "rust_decimal"] }
+tokio-util = { version = "0.7", features = ["compat"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "net", "time"] }
+async-trait = "0.1"
 
 [dev-dependencies]
-tokio = { version = "1.47.1", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ thiserror = "2.0.16"
 futures = "0.3"
 chrono = { version = "0.4.41", features = ["clock"] }
 base64 = "0.22"
-tiberius = { version = "0.12.3", default-features = false, features = ["native-tls", "tds73", "chrono", "rust_decimal"] }
+tiberius = { version = "0.12.3", default-features = false, features = ["tls-native", "tds73", "chrono", "rust_decimal"] }
 tokio-util = { version = "0.7", features = ["compat"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "net", "time"] }
 async-trait = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ thiserror = "2.0.16"
 futures = "0.3"
 chrono = { version = "0.4.41", features = ["clock"] }
 base64 = "0.22"
-tiberius = { version = "0.12.3", features = ["native-tls", "tds73", "chrono", "rust_decimal"] }
+tiberius = { version = "0.12.3", default-features = false, features = ["native-tls", "tds73", "chrono", "rust_decimal"] }
 tokio-util = { version = "0.7", features = ["compat"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "net", "time"] }
 async-trait = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ thiserror = "2.0.16"
 futures = "0.3"
 chrono = { version = "0.4.41", features = ["clock"] }
 base64 = "0.22"
-tiberius = { version = "0.12.3", default-features = false, features = ["tls-native", "tds73", "chrono", "rust_decimal"] }
+tiberius = { version = "0.12.3", default-features = false, features = ["native-tls", "tds73", "chrono", "rust_decimal"] }
 tokio-util = { version = "0.7", features = ["compat"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "net", "time"] }
 async-trait = "0.1"

--- a/src/dataset/data_cell.rs
+++ b/src/dataset/data_cell.rs
@@ -1,0 +1,6 @@
+use super::DataValue;
+
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct DataCell {
+    pub value: DataValue,
+}

--- a/src/dataset/data_column.rs
+++ b/src/dataset/data_column.rs
@@ -1,0 +1,7 @@
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct DataColumn {
+    pub name: String,
+    pub sql_type: String,
+    pub size: Option<u32>,
+    pub nullable: bool,
+}

--- a/src/dataset/data_row.rs
+++ b/src/dataset/data_row.rs
@@ -12,6 +12,6 @@ impl Index<&str> for DataRow {
     type Output = DataValue;
 
     fn index(&self, column: &str) -> &Self::Output {
-        &self.cells.get(column).expect("unknown column").value
+        &self.cells.get(column).expect(&format!("Column '{}' not found", column)).value
     }
 }

--- a/src/dataset/data_row.rs
+++ b/src/dataset/data_row.rs
@@ -1,0 +1,17 @@
+use std::collections::HashMap;
+use std::ops::Index;
+
+use super::{DataCell, DataValue};
+
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct DataRow {
+    pub cells: HashMap<String, DataCell>,
+}
+
+impl Index<&str> for DataRow {
+    type Output = DataValue;
+
+    fn index(&self, column: &str) -> &Self::Output {
+        &self.cells.get(column).expect("unknown column").value
+    }
+}

--- a/src/dataset/data_set.rs
+++ b/src/dataset/data_set.rs
@@ -1,0 +1,16 @@
+use std::collections::HashMap;
+
+use super::DataTable;
+
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct DataSet {
+    pub tables: HashMap<String, DataTable>,
+}
+
+impl DataSet {
+    pub fn new() -> Self {
+        Self {
+            tables: HashMap::new(),
+        }
+    }
+}

--- a/src/dataset/data_set_test.rs
+++ b/src/dataset/data_set_test.rs
@@ -1,0 +1,24 @@
+use super::*;
+use crate::dataset::{DataCell, DataColumn, DataRow, DataValue};
+
+#[test]
+fn create_dataset() {
+    let mut table = DataTable::new("table1");
+    table.columns.push(DataColumn {
+        name: "id".into(),
+        sql_type: "int".into(),
+        size: None,
+        nullable: false,
+    });
+    let mut row = DataRow::default();
+    row.cells.insert(
+        "id".into(),
+        DataCell {
+            value: DataValue::Int(1),
+        },
+    );
+    table.rows.push(row);
+    let mut ds = DataSet::new();
+    ds.tables.insert(table.name.clone(), table);
+    assert_eq!(ds.tables["table1"][0]["id"], DataValue::Int(1));
+}

--- a/src/dataset/data_table.rs
+++ b/src/dataset/data_table.rs
@@ -1,0 +1,28 @@
+use std::ops::Index;
+
+use super::{DataColumn, DataRow};
+
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct DataTable {
+    pub name: String,
+    pub columns: Vec<DataColumn>,
+    pub rows: Vec<DataRow>,
+}
+
+impl DataTable {
+    pub fn new(name: &str) -> Self {
+        Self {
+            name: name.into(),
+            columns: Vec::new(),
+            rows: Vec::new(),
+        }
+    }
+}
+
+impl Index<usize> for DataTable {
+    type Output = DataRow;
+
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.rows[index]
+    }
+}

--- a/src/dataset/data_value.rs
+++ b/src/dataset/data_value.rs
@@ -1,0 +1,30 @@
+#[derive(Debug, Clone, PartialEq)]
+pub enum DataValue {
+    Int(i32),
+    BigInt(i64),
+    Float(f64),
+    Bool(bool),
+    Text(String),
+    Binary(Vec<u8>),
+    Null,
+}
+
+impl DataValue {
+    pub fn to_tiberius(&self) -> Box<dyn tiberius::ToSql + Send + Sync> {
+        match self {
+            DataValue::Int(v) => Box::new(*v),
+            DataValue::BigInt(v) => Box::new(*v),
+            DataValue::Float(v) => Box::new(*v),
+            DataValue::Bool(v) => Box::new(*v),
+            DataValue::Text(v) => Box::new(v.clone()),
+            DataValue::Binary(v) => Box::new(v.clone()),
+            DataValue::Null => Box::new(Option::<i32>::None),
+        }
+    }
+}
+
+impl Default for DataValue {
+    fn default() -> Self {
+        DataValue::Null
+    }
+}

--- a/src/dataset/mod.rs
+++ b/src/dataset/mod.rs
@@ -1,0 +1,16 @@
+pub mod data_value;
+pub mod data_column;
+pub mod data_cell;
+pub mod data_row;
+pub mod data_table;
+pub mod data_set;
+
+pub use data_value::DataValue;
+pub use data_column::DataColumn;
+pub use data_cell::DataCell;
+pub use data_row::DataRow;
+pub use data_table::DataTable;
+pub use data_set::DataSet;
+
+#[cfg(test)]
+mod data_set_test;

--- a/src/infrastructure/mod.rs
+++ b/src/infrastructure/mod.rs
@@ -1,0 +1,1 @@
+pub mod mssql;

--- a/src/infrastructure/mssql/config.rs
+++ b/src/infrastructure/mssql/config.rs
@@ -1,0 +1,43 @@
+use tiberius::{AuthMethod, Config};
+
+#[derive(Debug, Clone)]
+pub struct MssqlConfig {
+    pub host: String,
+    pub port: u16,
+    pub username: String,
+    pub password: String,
+    pub database: String,
+    pub trust_cert: bool,
+}
+
+impl MssqlConfig {
+    pub fn new(
+        host: &str,
+        port: u16,
+        username: &str,
+        password: &str,
+        database: &str,
+        trust_cert: bool,
+    ) -> Self {
+        Self {
+            host: host.into(),
+            port,
+            username: username.into(),
+            password: password.into(),
+            database: database.into(),
+            trust_cert,
+        }
+    }
+
+    pub fn to_config(&self) -> Config {
+        let mut cfg = Config::new();
+        cfg.host(&self.host);
+        cfg.port(self.port);
+        cfg.database(&self.database);
+        cfg.authentication(AuthMethod::sql_server(&self.username, &self.password));
+        if self.trust_cert {
+            cfg.trust_cert();
+        }
+        cfg
+    }
+}

--- a/src/infrastructure/mssql/mod.rs
+++ b/src/infrastructure/mssql/mod.rs
@@ -1,0 +1,5 @@
+pub mod config;
+pub mod sql_connection;
+
+pub use config::MssqlConfig;
+pub use sql_connection::SqlConnection;

--- a/src/infrastructure/mssql/sql_connection.rs
+++ b/src/infrastructure/mssql/sql_connection.rs
@@ -1,0 +1,108 @@
+use anyhow::Result;
+use futures::StreamExt;
+use tiberius::{Client, QueryItem};
+use tokio::net::TcpStream;
+use tokio_util::compat::{Compat, TokioAsyncWriteCompatExt};
+
+use crate::dataset::{DataCell, DataColumn, DataRow, DataSet, DataTable, DataValue};
+
+use super::MssqlConfig;
+
+pub struct SqlConnection {
+    client: Client<Compat<TcpStream>>,
+}
+
+impl SqlConnection {
+    pub async fn connect(config: MssqlConfig) -> Result<Self> {
+        let cfg = config.to_config();
+        let addr = cfg.get_addr();
+        let tcp = TcpStream::connect(addr).await?;
+        tcp.set_nodelay(true)?;
+        let client = Client::connect(cfg, tcp.compat_write()).await?;
+        Ok(Self { client })
+    }
+
+    pub async fn execute(
+        &mut self,
+        sql: &str,
+        params: Vec<Box<dyn tiberius::ToSql + Send + Sync>>,
+    ) -> Result<DataSet> {
+        let param_refs: Vec<&dyn tiberius::ToSql> = params
+            .iter()
+            .map(|p| p.as_ref() as &dyn tiberius::ToSql)
+            .collect();
+        let mut stream = self.client.query(sql, &param_refs[..]).await?;
+        let mut dataset = DataSet::new();
+        let mut current: Option<DataTable> = None;
+        while let Some(item) = stream.next().await {
+            match item? {
+                QueryItem::Metadata(meta) => {
+                    if let Some(table) = current.take() {
+                        dataset.tables.insert(table.name.clone(), table);
+                    }
+                    let mut table = DataTable::new(&format!("table{}", meta.result_index()));
+                    table.columns = meta
+                        .columns()
+                        .iter()
+                        .map(|c| DataColumn {
+                            name: c.name().to_string(),
+                            sql_type: format!("{:?}", c.column_type()),
+                            size: None,
+                            nullable: true,
+                        })
+                        .collect();
+                    current = Some(table);
+                }
+                QueryItem::Row(row) => {
+                    if current.is_none() {
+                        current = Some(DataTable::new("table0"));
+                    }
+                    let table = current.as_mut().unwrap();
+                    let mut data_row = DataRow::default();
+                    for (cd, col) in row.into_iter().zip(table.columns.iter()) {
+                        let v = match cd {
+                            tiberius::ColumnData::I32(opt) => {
+                                opt.map(DataValue::Int).unwrap_or(DataValue::Null)
+                            }
+                            tiberius::ColumnData::I64(opt) => {
+                                opt.map(DataValue::BigInt).unwrap_or(DataValue::Null)
+                            }
+                            tiberius::ColumnData::F32(opt) => opt
+                                .map(|v| DataValue::Float(v as f64))
+                                .unwrap_or(DataValue::Null),
+                            tiberius::ColumnData::F64(opt) => {
+                                opt.map(DataValue::Float).unwrap_or(DataValue::Null)
+                            }
+                            tiberius::ColumnData::Bit(opt) => {
+                                opt.map(DataValue::Bool).unwrap_or(DataValue::Null)
+                            }
+                            tiberius::ColumnData::String(opt) => {
+                                if let Some(s) = opt.as_ref() {
+                                    DataValue::Text(s.to_string())
+                                } else {
+                                    DataValue::Null
+                                }
+                            }
+                            tiberius::ColumnData::Binary(opt) => {
+                                if let Some(b) = opt.as_ref() {
+                                    DataValue::Binary(b.to_vec())
+                                } else {
+                                    DataValue::Null
+                                }
+                            }
+                            _ => DataValue::Null,
+                        };
+                        data_row
+                            .cells
+                            .insert(col.name.clone(), DataCell { value: v });
+                    }
+                    table.rows.push(data_row);
+                }
+            }
+        }
+        if let Some(table) = current.take() {
+            dataset.tables.insert(table.name.clone(), table);
+        }
+        Ok(dataset)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,21 @@
+pub mod dataset;
+pub mod services;
+pub mod infrastructure;
+mod repositories;
+
+pub use repositories::{Command, CommandType, Parameter};
+pub use services::{dataset_service::DatasetService, service::Service};
+
+use anyhow::Result;
+use crate::dataset::DataSet;
+use crate::infrastructure::mssql::{MssqlConfig, SqlConnection};
+use crate::repositories::MssqlDatasetRepository;
+
+/// Execute a [`Command`] against the database using provided [`MssqlConfig`].
+/// This function wires up the internal repository and service layers.
+pub async fn execute(config: MssqlConfig, command: Command) -> Result<DataSet> {
+    let connection = SqlConnection::connect(config).await?;
+    let repo = MssqlDatasetRepository::new(connection);
+    let mut service = DatasetService::new(repo);
+    service.fetch(command).await
+}

--- a/src/repositories/command.rs
+++ b/src/repositories/command.rs
@@ -49,7 +49,11 @@ impl Command {
                         .iter()
                         .enumerate()
                         .map(|(i, p)| {
-                            let name = p.name.trim_start_matches('@');
+                            let name = if p.name.starts_with("@") {
+                                p.name.clone()
+                            } else {
+                                p.name.trim_start_matches('@').into()
+                            };
                             format!("@{} = @P{}", name, i + 1)
                         })
                         .collect::<Vec<_>>()

--- a/src/repositories/command.rs
+++ b/src/repositories/command.rs
@@ -50,7 +50,7 @@ impl Command {
                         .enumerate()
                         .map(|(i, p)| {
                             let name = p.name.trim_start_matches('@');
-                            format!("{} = @P{}", name, i)
+                            format!("{} = @P{}", name, i + 1)
                         })
                         .collect::<Vec<_>>()
                         .join(", ");

--- a/src/repositories/command.rs
+++ b/src/repositories/command.rs
@@ -50,7 +50,7 @@ impl Command {
                         .enumerate()
                         .map(|(i, p)| {
                             let name = p.name.trim_start_matches('@');
-                            format!("{} = @P{}", name, i + 1)
+                            format!("@{} = @P{}", name, i + 1)
                         })
                         .collect::<Vec<_>>()
                         .join(", ");

--- a/src/repositories/command.rs
+++ b/src/repositories/command.rs
@@ -50,9 +50,9 @@ impl Command {
                         .enumerate()
                         .map(|(i, p)| {
                             let name = if p.name.starts_with("@") {
-                                p.name.clone()
+                                p.name.trim_start_matches('@')
                             } else {
-                                p.name.trim_start_matches('@').into()
+                                p.name.as_str()
                             };
                             format!("@{} = @P{}", name, i + 1)
                         })

--- a/src/repositories/command.rs
+++ b/src/repositories/command.rs
@@ -1,0 +1,53 @@
+use super::parameter::Parameter;
+
+pub enum CommandType {
+    Text,
+    StoredProcedure,
+}
+
+pub struct Command {
+    pub text: String,
+    pub command_type: CommandType,
+    pub parameters: Vec<Parameter>,
+}
+
+impl Command {
+    pub fn query(text: &str) -> Self {
+        Self { text: text.into(), command_type: CommandType::Text, parameters: Vec::new() }
+    }
+
+    pub fn stored_procedure(name: &str) -> Self {
+        Self { text: name.into(), command_type: CommandType::StoredProcedure, parameters: Vec::new() }
+    }
+
+    pub fn with_param(mut self, param: Parameter) -> Self {
+        self.parameters.push(param);
+        self
+    }
+
+    pub fn build(&self) -> (String, Vec<Box<dyn tiberius::ToSql + Send + Sync>>) {
+        let params: Vec<Box<dyn tiberius::ToSql + Send + Sync>> = self
+            .parameters
+            .iter()
+            .map(|p| p.value.to_tiberius())
+            .collect();
+        match self.command_type {
+            CommandType::Text => (self.text.clone(), params),
+            CommandType::StoredProcedure => {
+                let mut sql = format!("EXEC {}", self.text);
+                if !self.parameters.is_empty() {
+                    let param_str = self
+                        .parameters
+                        .iter()
+                        .enumerate()
+                        .map(|(i, p)| format!("{} = @P{}", p.name, i))
+                        .collect::<Vec<_>>()
+                        .join(", ");
+                    sql.push(' ');
+                    sql.push_str(&param_str);
+                }
+                (sql, params)
+            }
+        }
+    }
+}

--- a/src/repositories/command.rs
+++ b/src/repositories/command.rs
@@ -13,11 +13,19 @@ pub struct Command {
 
 impl Command {
     pub fn query(text: &str) -> Self {
-        Self { text: text.into(), command_type: CommandType::Text, parameters: Vec::new() }
+        Self {
+            text: text.into(),
+            command_type: CommandType::Text,
+            parameters: Vec::new(),
+        }
     }
 
     pub fn stored_procedure(name: &str) -> Self {
-        Self { text: name.into(), command_type: CommandType::StoredProcedure, parameters: Vec::new() }
+        Self {
+            text: name.into(),
+            command_type: CommandType::StoredProcedure,
+            parameters: Vec::new(),
+        }
     }
 
     pub fn with_param(mut self, param: Parameter) -> Self {
@@ -40,7 +48,10 @@ impl Command {
                         .parameters
                         .iter()
                         .enumerate()
-                        .map(|(i, p)| format!("{} = @P{}", p.name, i))
+                        .map(|(i, p)| {
+                            let name = p.name.trim_start_matches('@');
+                            format!("{} = @P{}", name, i)
+                        })
                         .collect::<Vec<_>>()
                         .join(", ");
                     sql.push(' ');

--- a/src/repositories/dataset_repository.rs
+++ b/src/repositories/dataset_repository.rs
@@ -1,0 +1,29 @@
+use anyhow::Result;
+use async_trait::async_trait;
+
+use crate::dataset::DataSet;
+
+use super::{command::Command, query_executor::QueryExecutor};
+
+#[async_trait]
+pub trait DatasetRepository {
+    async fn execute(&mut self, command: Command) -> Result<DataSet>;
+}
+
+pub struct MssqlDatasetRepository<E: QueryExecutor + Send> {
+    executor: E,
+}
+
+impl<E: QueryExecutor + Send> MssqlDatasetRepository<E> {
+    pub fn new(executor: E) -> Self {
+        Self { executor }
+    }
+}
+
+#[async_trait]
+impl<E: QueryExecutor + Send> DatasetRepository for MssqlDatasetRepository<E> {
+    async fn execute(&mut self, command: Command) -> Result<DataSet> {
+        let (sql, params) = command.build();
+        self.executor.query(&sql, params).await
+    }
+}

--- a/src/repositories/dataset_repository_test.rs
+++ b/src/repositories/dataset_repository_test.rs
@@ -33,10 +33,10 @@ async fn test_query_command() {
     let sql_ref = exec.last_sql.clone();
     let params_ref = exec.last_params.clone();
     let mut repo = MssqlDatasetRepository::new(exec);
-    let cmd = Command::query("SELECT 1 WHERE id = @P0")
-        .with_param(Parameter::new("id", DataValue::Int(1)));
+    let cmd = Command::query("SELECT 1 WHERE id = @P1")
+        .with_param(Parameter::new("P1", DataValue::Int(1)));
     repo.execute(cmd).await.unwrap();
-    assert_eq!(*sql_ref.lock().unwrap(), "SELECT 1 WHERE id = @P0");
+    assert_eq!(*sql_ref.lock().unwrap(), "SELECT 1 WHERE id = @P1");
     assert_eq!(*params_ref.lock().unwrap(), 1);
 }
 
@@ -52,7 +52,7 @@ async fn test_sp_command() {
     let cmd =
         Command::stored_procedure("sp_test").with_param(Parameter::new("id", DataValue::Int(1)));
     repo.execute(cmd).await.unwrap();
-    assert_eq!(*sql_ref.lock().unwrap(), "EXEC sp_test id = @P0");
+    assert_eq!(*sql_ref.lock().unwrap(), "EXEC sp_test id = @P1");
     assert_eq!(*params_ref.lock().unwrap(), 1);
 }
 
@@ -68,6 +68,6 @@ async fn test_sp_command_with_at_prefix() {
     let cmd =
         Command::stored_procedure("sp_test").with_param(Parameter::new("@id", DataValue::Int(1)));
     repo.execute(cmd).await.unwrap();
-    assert_eq!(*sql_ref.lock().unwrap(), "EXEC sp_test id = @P0");
+    assert_eq!(*sql_ref.lock().unwrap(), "EXEC sp_test id = @P1");
     assert_eq!(*params_ref.lock().unwrap(), 1);
 }

--- a/src/repositories/dataset_repository_test.rs
+++ b/src/repositories/dataset_repository_test.rs
@@ -1,0 +1,45 @@
+use super::*;
+use super::query_executor::QueryExecutor;
+use anyhow::Result;
+use async_trait::async_trait;
+use crate::dataset::{DataSet, DataValue};
+use crate::repositories::Parameter;
+use std::sync::{Arc, Mutex};
+
+struct MockExecutor {
+    pub last_sql: Arc<Mutex<String>>,
+    pub last_params: Arc<Mutex<usize>>,
+}
+
+#[async_trait]
+impl QueryExecutor for MockExecutor {
+    async fn query(&mut self, sql: &str, params: Vec<Box<dyn tiberius::ToSql + Send + Sync>>) -> Result<DataSet> {
+        *self.last_sql.lock().unwrap() = sql.to_string();
+        *self.last_params.lock().unwrap() = params.len();
+        Ok(DataSet::new())
+    }
+}
+
+#[tokio::test]
+async fn test_query_command() {
+    let exec = MockExecutor { last_sql: Arc::new(Mutex::new(String::new())), last_params: Arc::new(Mutex::new(0)) };
+    let sql_ref = exec.last_sql.clone();
+    let params_ref = exec.last_params.clone();
+    let mut repo = MssqlDatasetRepository::new(exec);
+    let cmd = Command::query("SELECT 1 WHERE id = @P0").with_param(Parameter::new("id", DataValue::Int(1)));
+    repo.execute(cmd).await.unwrap();
+    assert_eq!(*sql_ref.lock().unwrap(), "SELECT 1 WHERE id = @P0");
+    assert_eq!(*params_ref.lock().unwrap(), 1);
+}
+
+#[tokio::test]
+async fn test_sp_command() {
+    let exec = MockExecutor { last_sql: Arc::new(Mutex::new(String::new())), last_params: Arc::new(Mutex::new(0)) };
+    let sql_ref = exec.last_sql.clone();
+    let params_ref = exec.last_params.clone();
+    let mut repo = MssqlDatasetRepository::new(exec);
+    let cmd = Command::stored_procedure("sp_test").with_param(Parameter::new("id", DataValue::Int(1)));
+    repo.execute(cmd).await.unwrap();
+    assert_eq!(*sql_ref.lock().unwrap(), "EXEC sp_test id = @P0");
+    assert_eq!(*params_ref.lock().unwrap(), 1);
+}

--- a/src/repositories/dataset_repository_test.rs
+++ b/src/repositories/dataset_repository_test.rs
@@ -52,7 +52,7 @@ async fn test_sp_command() {
     let cmd =
         Command::stored_procedure("sp_test").with_param(Parameter::new("id", DataValue::Int(1)));
     repo.execute(cmd).await.unwrap();
-    assert_eq!(*sql_ref.lock().unwrap(), "EXEC sp_test id = @P1");
+    assert_eq!(*sql_ref.lock().unwrap(), "EXEC sp_test @id = @P1");
     assert_eq!(*params_ref.lock().unwrap(), 1);
 }
 
@@ -68,6 +68,6 @@ async fn test_sp_command_with_at_prefix() {
     let cmd =
         Command::stored_procedure("sp_test").with_param(Parameter::new("@id", DataValue::Int(1)));
     repo.execute(cmd).await.unwrap();
-    assert_eq!(*sql_ref.lock().unwrap(), "EXEC sp_test id = @P1");
+    assert_eq!(*sql_ref.lock().unwrap(), "EXEC sp_test @id = @P1");
     assert_eq!(*params_ref.lock().unwrap(), 1);
 }

--- a/src/repositories/mod.rs
+++ b/src/repositories/mod.rs
@@ -1,0 +1,11 @@
+mod command;
+mod parameter;
+mod query_executor;
+mod dataset_repository;
+
+pub use command::{Command, CommandType};
+pub use parameter::Parameter;
+pub(crate) use dataset_repository::{DatasetRepository, MssqlDatasetRepository};
+
+#[cfg(test)]
+mod dataset_repository_test;

--- a/src/repositories/parameter.rs
+++ b/src/repositories/parameter.rs
@@ -1,0 +1,12 @@
+use crate::dataset::DataValue;
+
+pub struct Parameter {
+    pub name: String,
+    pub value: DataValue,
+}
+
+impl Parameter {
+    pub fn new(name: &str, value: DataValue) -> Self {
+        Self { name: name.into(), value }
+    }
+}

--- a/src/repositories/query_executor.rs
+++ b/src/repositories/query_executor.rs
@@ -1,0 +1,18 @@
+use anyhow::Result;
+use async_trait::async_trait;
+
+use crate::dataset::DataSet;
+
+use crate::infrastructure::mssql::SqlConnection;
+
+#[async_trait]
+pub trait QueryExecutor {
+    async fn query(&mut self, sql: &str, params: Vec<Box<dyn tiberius::ToSql + Send + Sync>>) -> Result<DataSet>;
+}
+
+#[async_trait]
+impl QueryExecutor for SqlConnection {
+    async fn query(&mut self, sql: &str, params: Vec<Box<dyn tiberius::ToSql + Send + Sync>>) -> Result<DataSet> {
+        self.execute(sql, params).await
+    }
+}

--- a/src/services/dataset_service.rs
+++ b/src/services/dataset_service.rs
@@ -1,0 +1,23 @@
+use anyhow::Result;
+use async_trait::async_trait;
+
+use crate::{dataset::DataSet, repositories::{Command, DatasetRepository}};
+
+use super::service::Service;
+
+pub struct DatasetService<R: DatasetRepository + Send> {
+    repository: R,
+}
+
+impl<R: DatasetRepository + Send> DatasetService<R> {
+    pub fn new(repository: R) -> Self {
+        Self { repository }
+    }
+}
+
+#[async_trait]
+impl<R: DatasetRepository + Send> Service for DatasetService<R> {
+    async fn fetch(&mut self, command: Command) -> Result<DataSet> {
+        self.repository.execute(command).await
+    }
+}

--- a/src/services/dataset_service_test.rs
+++ b/src/services/dataset_service_test.rs
@@ -1,0 +1,26 @@
+use super::*;
+use anyhow::Result;
+use async_trait::async_trait;
+use crate::{dataset::DataSet, repositories::{Command, DatasetRepository}};
+use std::sync::{Arc, Mutex};
+
+struct MockRepo {
+    pub called: Arc<Mutex<bool>>,
+}
+
+#[async_trait]
+impl DatasetRepository for MockRepo {
+    async fn execute(&mut self, _command: Command) -> Result<DataSet> {
+        *self.called.lock().unwrap() = true;
+        Ok(DataSet::new())
+    }
+}
+
+#[tokio::test]
+async fn service_calls_repository() {
+    let repo = MockRepo { called: Arc::new(Mutex::new(false)) };
+    let called_ref = repo.called.clone();
+    let mut service = DatasetService::new(repo);
+    service.fetch(Command::query("SELECT 1")).await.unwrap();
+    assert_eq!(*called_ref.lock().unwrap(), true);
+}

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -1,0 +1,8 @@
+pub mod service;
+pub mod dataset_service;
+
+pub use service::Service;
+pub use dataset_service::DatasetService;
+
+#[cfg(test)]
+mod dataset_service_test;

--- a/src/services/service.rs
+++ b/src/services/service.rs
@@ -1,0 +1,9 @@
+use anyhow::Result;
+use async_trait::async_trait;
+
+use crate::{dataset::DataSet, repositories::Command};
+
+#[async_trait]
+pub trait Service {
+    async fn fetch(&mut self, command: Command) -> Result<DataSet>;
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -30,7 +30,7 @@ async fn query_with_params() {
         true,
     );
     let cmd =
-        Command::query("SELECT @P0 as value").with_param(Parameter::new("p", DataValue::Int(7)));
+        Command::query("SELECT @P0 as value").with_param(Parameter::new("P0", DataValue::Int(7)));
     let ds = execute(config, cmd).await.unwrap();
     assert_eq!(ds.tables["table0"][0]["value"], DataValue::Int(7));
 }
@@ -79,7 +79,7 @@ async fn stored_procedure_with_params() {
     execute(config.clone(), create).await.unwrap();
 
     let cmd = Command::stored_procedure("sp_with_param")
-        .with_param(Parameter::new("@val", DataValue::Int(5)));
+        .with_param(Parameter::new("val", DataValue::Int(5)));
     let ds = execute(config, cmd).await.unwrap();
     assert_eq!(ds.tables["table0"][0]["value"], DataValue::Int(5));
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -30,7 +30,7 @@ async fn query_with_params() {
         true,
     );
     let cmd =
-        Command::query("SELECT @P0 as value").with_param(Parameter::new("P0", DataValue::Int(7)));
+        Command::query("SELECT @P1 as value").with_param(Parameter::new("P1", DataValue::Int(7)));
     let ds = execute(config, cmd).await.unwrap();
     assert_eq!(ds.tables["table0"][0]["value"], DataValue::Int(7));
 }
@@ -46,12 +46,11 @@ async fn stored_procedure() {
         "master",
         true,
     );
-    let create = Command::query(
-        r#"
-        IF OBJECT_ID('sp_no_params', 'P') IS NOT NULL DROP PROCEDURE sp_no_params;
-        CREATE PROCEDURE sp_no_params AS BEGIN SELECT 2 AS value; END
-    "#,
+    let drop = Command::query(
+        "IF OBJECT_ID('sp_no_params', 'P') IS NOT NULL DROP PROCEDURE sp_no_params;",
     );
+    execute(config.clone(), drop).await.unwrap();
+    let create = Command::query("CREATE PROCEDURE sp_no_params AS BEGIN SELECT 2 AS value; END");
     execute(config.clone(), create).await.unwrap();
 
     let cmd = Command::stored_procedure("sp_no_params");
@@ -70,11 +69,12 @@ async fn stored_procedure_with_params() {
         "master",
         true,
     );
+    let drop = Command::query(
+        "IF OBJECT_ID('sp_with_param', 'P') IS NOT NULL DROP PROCEDURE sp_with_param;",
+    );
+    execute(config.clone(), drop).await.unwrap();
     let create = Command::query(
-        r#"
-        IF OBJECT_ID('sp_with_param', 'P') IS NOT NULL DROP PROCEDURE sp_with_param;
-        CREATE PROCEDURE sp_with_param @val INT AS BEGIN SELECT @val AS value; END
-    "#,
+        "CREATE PROCEDURE sp_with_param @val INT AS BEGIN SELECT @val AS value; END",
     );
     execute(config.clone(), create).await.unwrap();
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,0 +1,85 @@
+use mssqlrust::dataset::DataValue;
+use mssqlrust::infrastructure::mssql::MssqlConfig;
+use mssqlrust::{execute, Command, Parameter};
+
+#[tokio::test]
+#[ignore]
+async fn basic_query() {
+    let config = MssqlConfig::new(
+        "localhost",
+        1433,
+        "sa",
+        "YourStrong!Passw0rd",
+        "master",
+        true,
+    );
+    let cmd = Command::query("SELECT 1 as value");
+    let ds = execute(config, cmd).await.unwrap();
+    assert_eq!(ds.tables["table0"][0]["value"], DataValue::Int(1));
+}
+
+#[tokio::test]
+#[ignore]
+async fn query_with_params() {
+    let config = MssqlConfig::new(
+        "localhost",
+        1433,
+        "sa",
+        "YourStrong!Passw0rd",
+        "master",
+        true,
+    );
+    let cmd =
+        Command::query("SELECT @P0 as value").with_param(Parameter::new("p", DataValue::Int(7)));
+    let ds = execute(config, cmd).await.unwrap();
+    assert_eq!(ds.tables["table0"][0]["value"], DataValue::Int(7));
+}
+
+#[tokio::test]
+#[ignore]
+async fn stored_procedure() {
+    let config = MssqlConfig::new(
+        "localhost",
+        1433,
+        "sa",
+        "YourStrong!Passw0rd",
+        "master",
+        true,
+    );
+    let create = Command::query(
+        r#"
+        IF OBJECT_ID('sp_no_params', 'P') IS NOT NULL DROP PROCEDURE sp_no_params;
+        CREATE PROCEDURE sp_no_params AS BEGIN SELECT 2 AS value; END
+    "#,
+    );
+    execute(config.clone(), create).await.unwrap();
+
+    let cmd = Command::stored_procedure("sp_no_params");
+    let ds = execute(config, cmd).await.unwrap();
+    assert_eq!(ds.tables["table0"][0]["value"], DataValue::Int(2));
+}
+
+#[tokio::test]
+#[ignore]
+async fn stored_procedure_with_params() {
+    let config = MssqlConfig::new(
+        "localhost",
+        1433,
+        "sa",
+        "YourStrong!Passw0rd",
+        "master",
+        true,
+    );
+    let create = Command::query(
+        r#"
+        IF OBJECT_ID('sp_with_param', 'P') IS NOT NULL DROP PROCEDURE sp_with_param;
+        CREATE PROCEDURE sp_with_param @val INT AS BEGIN SELECT @val AS value; END
+    "#,
+    );
+    execute(config.clone(), create).await.unwrap();
+
+    let cmd = Command::stored_procedure("sp_with_param")
+        .with_param(Parameter::new("@val", DataValue::Int(5)));
+    let ds = execute(config, cmd).await.unwrap();
+    assert_eq!(ds.tables["table0"][0]["value"], DataValue::Int(5));
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -17,6 +17,17 @@ async fn run_ddl(config: &MssqlConfig, sql: &str) {
     while stream.next().await.is_some() {}
 }
 
+fn test_config() -> MssqlConfig {
+    MssqlConfig::new(
+        "localhost",
+        1433,
+        "sa",
+        "YourStrong!Passw0rd",
+        "master",
+        true,
+    )
+}
+
 #[tokio::test]
 #[ignore]
 async fn basic_query() {

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -20,14 +20,7 @@ async fn run_ddl(config: &MssqlConfig, sql: &str) {
 #[tokio::test]
 #[ignore]
 async fn basic_query() {
-    let config = MssqlConfig::new(
-        "localhost",
-        1433,
-        "sa",
-        "YourStrong!Passw0rd",
-        "master",
-        true,
-    );
+    let config = test_config();
     let cmd = Command::query("SELECT 1 as value");
     let ds = execute(config, cmd).await.unwrap();
     assert_eq!(ds.tables["table0"][0]["value"], DataValue::Int(1));


### PR DESCRIPTION
## Summary
- rename low-level Tiberius executor to SqlConnection and update exports
- hide repository module from the public API and expose a service-driven `execute` entry point
- expand integration tests to cover stored procedures and parameterized queries

## Testing
- `cargo test`
- `cargo test -- --ignored` *(fails: Connection refused (os error 111))*

------
https://chatgpt.com/codex/tasks/task_e_68ad340493d08320a2971210fba1d319