### PR TITLE
feat: publish crate on release using tag version

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,24 @@
+name: Publish to crates.io
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - name: Install cargo-edit
+        run: cargo install cargo-edit
+      - name: Set version from tag
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          cargo set-version "$version"
+      - run: cargo publish --locked
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,6 +19,8 @@ jobs:
         run: |
           version="${GITHUB_REF_NAME#v}"
           cargo set-version "$version"
-      - run: cargo publish --locked
+      - name: Validate package before publishing
+        run: cargo publish --dry-run
+      - run: cargo publish
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
## Summary
- publish workflow triggers when a release is published
- set crate version from release tag before publishing to crates.io

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68b0c3f162b08320884e769ea9745546