### PR TITLE
Add execute scalar

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@ pub use repositories::{Command, CommandType, Parameter};
 pub use services::{dataset_service::DatasetService, service::Service};
 
 use anyhow::Result;
-use crate::dataset::DataSet;
+use crate::dataset::{DataSet, DataValue};
 use crate::infrastructure::mssql::{MssqlConfig, SqlConnection};
 use crate::repositories::MssqlDatasetRepository;
 
@@ -27,4 +27,12 @@ pub async fn execute_non_query(config: MssqlConfig, command: Command) -> Result<
     let mut connection = SqlConnection::connect(config).await?;
     let (sql, params) = command.build();
     connection.execute_non_query(&sql, params).await
+}
+
+/// Execute a [`Command`] and return the first column of the first row
+/// as a `DataValue`. If the command returns no rows, returns `Ok(None)`.
+pub async fn execute_scalar(config: MssqlConfig, command: Command) -> Result<Option<DataValue>> {
+    let mut connection = SqlConnection::connect(config).await?;
+    let (sql, params) = command.build();
+    connection.execute_scalar(&sql, params).await
 }


### PR DESCRIPTION
This pull request introduces support for scalar queries to the `mssqlrust` crate, allowing users to easily retrieve the first column of the first row from a SQL query or stored procedure. The documentation has been reorganized and expanded to better explain usage patterns, and the codebase now includes new APIs, internal mapping logic, and tests for this feature.

**New Scalar Query Support:**

* Added the `execute_scalar` API to return the first column of the first row as a `DataValue`, including documentation and usage examples in `README.md`. [[1]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759R31-R38) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R158-R188)
* Implemented the `SqlConnection::execute_scalar` method, which executes the query and extracts the scalar value, along with the internal `map_column_data` function to convert SQL types to crate types.

**Documentation Improvements:**

* Reorganized and expanded the `README.md` to clarify basic, parameterized, non-query, and scalar query usage, including updated examples and clearer explanations. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L11-L45) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L72-R120) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R158-R188)

**Testing:**

* Added unit tests for type mapping and integration tests for the scalar query and stored procedure functionality. [[1]](diffhunk://#diff-868c4036fd5ee25cf40d5aadabcfba906741f927016ace66572416cfd593f913R324-R332) [[2]](diffhunk://#diff-7ff815b68943f08bef79f083c09e55ca8c18db8e25033034b12fa31f1d43dab4R245-R270)

**Dependency Update:**

* Updated the `mssqlrust` version in `Cargo.toml` usage instructions from `1.0.0` to `1.0.2`.

**Exports:**

* Exported `DataValue` from the crate root for easier access to scalar results.